### PR TITLE
fix: only get balance data when msisdn is known

### DIFF
--- a/custom_components/mobile_vikings/client.py
+++ b/custom_components/mobile_vikings/client.py
@@ -234,13 +234,16 @@ class MobileVikingsClient:
                     f"/subscriptions/{subscription_id}/modem/settings"
                 )
             else:
-                balance = await self.handle_request(
-                    f"/subscriptions/{subscription_id}/balance"
-                )
-                subscription["balance"] = balance
-                subscription["balance_aggregated"] = self.aggregate_bundles_by_type(
-                    balance
-                )
+               # Check if the 'sim' field exists and 'msisdn' is not empty
+               sim_info = subscription.get("sim", {})
+               if sim_info.get("msisdn"):
+                   balance = await self.handle_request(
+                       f"/subscriptions/{subscription_id}/balance"
+                   )
+                   subscription["balance"] = balance
+                   subscription["balance_aggregated"] = self.aggregate_bundles_by_type(
+                       balance
+                   )
             subscription["product"] = await self.get_product_details(
                 subscription.get("product_id")
             )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved subscription balance retrieval logic to prevent unnecessary API calls
	- Added conditional check to fetch balance only for valid SIM subscriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->